### PR TITLE
Message restructuring & New Binder/Connector

### DIFF
--- a/callosum/__init__.py
+++ b/callosum/__init__.py
@@ -1,3 +1,7 @@
+import abc
+from typing import Tuple
+import msgpack
+
 from .peer import Peer
 
 __all__ = (
@@ -5,3 +9,30 @@ __all__ = (
 )
 
 __version__ = '0.0.1'
+
+
+class AbstractMessage(metaclass=abc.ABCMeta):
+
+    @classmethod
+    @abc.abstractmethod
+    def decode(cls):
+        '''
+        Decodes the message and applies deserializer to the body.
+        Returns an instance of inheriting message class.
+        '''
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def encode(self) -> Tuple[bytes, bytes]:
+        '''
+        Encodes the message and applies serializer to body.
+        '''
+        raise NotImplementedError
+
+    @staticmethod
+    def mpackb(v):
+        return msgpack.packb(v, use_bin_type=True)
+
+    @staticmethod
+    def munpackb(b):
+        return msgpack.unpackb(b, raw=False, use_list=False)

--- a/callosum/eventmessage.py
+++ b/callosum/eventmessage.py
@@ -45,12 +45,12 @@ class EventMessage(AbstractMessage):
 
     @classmethod
     def decode(cls, raw_msg: Tuple[bytes, bytes], deserializer):
-        header = EventMessage.munpackb(raw_msg[0])
+        header = cls.munpackb(raw_msg[0])
         event = EventTypes(header['event'])
         # format string assumes that datetime object includes timezone!
         fmt = "%y/%m/%d, %H:%M:%S:%f, %z%Z"
         timestamp = datetime.datetime.strptime(header['timestamp'], fmt)
-        body = EventMessage.munpackb(raw_msg[1])
+        body = cls.munpackb(raw_msg[1])
         return cls(event,
                    header['agent_id'],
                    timestamp,
@@ -67,10 +67,10 @@ class EventMessage(AbstractMessage):
             'agent_id': self.agent_id,
             'timestamp': timestamp,
         }
-        serialized_header: bytes = EventMessage.mpackb(header)
+        serialized_header: bytes = self.mpackb(header)
         args = serializer(self.args)
         body = {
             'args': args,
         }
-        serialized_body: bytes = EventMessage.mpackb(body)
+        serialized_body: bytes = self.mpackb(body)
         return (serialized_header, serialized_body)

--- a/callosum/eventmessage.py
+++ b/callosum/eventmessage.py
@@ -1,0 +1,76 @@
+import enum
+import datetime
+from typing import Tuple
+
+import attr
+from . import (
+    AbstractMessage,
+)
+
+
+class EventTypes(enum.IntEnum):
+    INSTANCE_STARTED = 0
+    INSTANCE_TERMINATED = 1
+    INSTANCE_HEARTBEAT = 2
+    KERNEL_PREPARING = 3
+    KERNEL_CREATING = 4
+    KERNEL_PULLING = 5
+    KERNEL_STARTED = 6
+    KERNEL_TERMINATED = 7
+
+
+@attr.dataclass(frozen=True, slots=True)
+class EventMessage(AbstractMessage):
+    # header parts
+    event: EventTypes
+    agent_id: str
+    timestamp: datetime.datetime
+
+    # body parts
+    args: list
+
+    @property
+    def header(self):
+        return (self.event, self.agent_id, self.timestamp)
+
+    @property
+    def body(self):
+        return self.args
+
+    @classmethod
+    def create(cls, event: EventTypes,
+               agent_id: str, timestamp: datetime.datetime, *args):
+        return cls(event, agent_id,
+                    timestamp, args)
+
+    @classmethod
+    def decode(cls, raw_msg: Tuple[bytes, bytes], deserializer):
+        header = EventMessage.munpackb(raw_msg[0])
+        event = EventTypes(header['event'])
+        # format string assumes that datetime object includes timezone!
+        fmt = "%y/%m/%d, %H:%M:%S:%f, %z%Z"
+        timestamp = datetime.datetime.strptime(header['timestamp'], fmt)
+        body = EventMessage.munpackb(raw_msg[1])
+        return cls(event,
+                   header['agent_id'],
+                   timestamp,
+                   deserializer(body['args']))
+
+    def encode(self, serializer, compress: bool = True) \
+              -> Tuple[bytes, bytes]:
+        event = int(self.event)
+        # format string assumes that datetime object includes timezone!
+        fmt = "%y/%m/%d, %H:%M:%S:%f, %z%Z"
+        timestamp: str = self.timestamp.strftime(fmt)
+        header = {
+            'event': event,
+            'agent_id': self.agent_id,
+            'timestamp': timestamp,
+        }
+        serialized_header: bytes = EventMessage.mpackb(header)
+        args = serializer(self.args)
+        body = {
+            'args': args,
+        }
+        serialized_body: bytes = EventMessage.mpackb(body)
+        return (serialized_header, serialized_body)

--- a/callosum/exceptions.py
+++ b/callosum/exceptions.py
@@ -11,9 +11,9 @@ class ParamError(ClientError):
     def __init__(self, error_param: str):
         self.message =\
             f'''
-            {error_param} must not be specified in RedisStreamAddress,\
-                 as objects using CommonStreamBinder are not supposed\
-                      to be the consumers of any group.
+            {error_param} must not be specified in RedisStreamAddress,
+            as objects using CommonStreamBinder are not supposed
+            to be the consumers of any group.
             '''
 
 

--- a/callosum/exceptions.py
+++ b/callosum/exceptions.py
@@ -2,11 +2,7 @@ class CallosumError(Exception):
     pass
 
 
-class ClientError(CallosumError):
-    pass
-
-
-class ParamError(ClientError):
+class ParamError(CallosumError, ValueError):
 
     def __init__(self, error_param: str):
         self.message =\
@@ -15,6 +11,10 @@ class ParamError(ClientError):
             as objects using CommonStreamBinder are not supposed
             to be the consumers of any group.
             '''
+
+
+class ClientError(CallosumError):
+    pass
 
 
 class ServerError(CallosumError):

--- a/callosum/exceptions.py
+++ b/callosum/exceptions.py
@@ -6,6 +6,17 @@ class ClientError(CallosumError):
     pass
 
 
+class ParamError(ClientError):
+
+    def __init__(self, error_param: str):
+        self.message =\
+            f'''
+            {error_param} must not be specified in RedisStreamAddress,\
+                 as objects using CommonStreamBinder are not supposed\
+                      to be the consumers of any group.
+            '''
+
+
 class ServerError(CallosumError):
     pass
 

--- a/callosum/lower/__init__.py
+++ b/callosum/lower/__init__.py
@@ -17,6 +17,24 @@ class AbstractMessagingMixin(metaclass=abc.ABCMeta):
     async def send_message(self, raw_msg: Tuple[bytes, bytes]) -> None:
         raise NotImplementedError
 
+class AbstractMessage(metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    @classmethod
+    def decode(self):
+        '''
+        Decodes the message and applies deserializer to the body.
+        Returns an instance of inheriting message class.
+        '''
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def encode(self) -> Tuple[bytes, bytes]:
+        '''
+        Encodes the message and applies serializer to body.
+        '''
+        raise NotImplementedError
+
 
 class AbstractAddress:
     pass

--- a/callosum/lower/__init__.py
+++ b/callosum/lower/__init__.py
@@ -17,24 +17,6 @@ class AbstractMessagingMixin(metaclass=abc.ABCMeta):
     async def send_message(self, raw_msg: Tuple[bytes, bytes]) -> None:
         raise NotImplementedError
 
-class AbstractMessage(metaclass=abc.ABCMeta):
-
-    @abc.abstractmethod
-    @classmethod
-    def decode(self):
-        '''
-        Decodes the message and applies deserializer to the body.
-        Returns an instance of inheriting message class.
-        '''
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def encode(self) -> Tuple[bytes, bytes]:
-        '''
-        Encodes the message and applies serializer to body.
-        '''
-        raise NotImplementedError
-
 
 class AbstractAddress:
     pass

--- a/callosum/lower/redis.py
+++ b/callosum/lower/redis.py
@@ -12,6 +12,7 @@ from . import (
     AbstractConnection,
     BaseTransport,
 )
+from ..exceptions import ClientError
 # from ..auth import Identity
 # from ..compat import current_loop
 
@@ -20,8 +21,8 @@ from . import (
 class RedisStreamAddress(AbstractAddress):
     redis_server: Union[str, Tuple[str, int]]
     stream_key: str
-    group: Optional[str] = None     # only required by receiver-side
-    consumer: Optional[str] = None  # only required by receiver-side
+    group: Optional[str] = None     # only required by receiver-side; must not be specified for CommonStreamBinder
+    consumer: Optional[str] = None  # only required by receiver-side; must not be specified for CommonStreamBinder
 
 
 class RedisStreamConnection(AbstractConnection):
@@ -34,7 +35,7 @@ class RedisStreamConnection(AbstractConnection):
 
     def __init__(self, transport: RedisStreamTransport,
                  addr: RedisStreamAddress,
-                 direction_keys: Tuple[str, str]):
+                 direction_keys: Optional[Tuple[str, str]] = None):
         self.transport = transport
         self.addr = addr
         self.direction_keys = direction_keys
@@ -42,7 +43,10 @@ class RedisStreamConnection(AbstractConnection):
     async def recv_message(self) -> AsyncGenerator[
             Optional[Tuple[bytes, bytes]], None]:
         # assert not self.transport._redis.closed
-        stream_key = f'{self.addr.stream_key}.{self.direction_keys[0]}'
+        if not self.direction_keys:
+            stream_key = self.addr.stream_key
+        else:
+            stream_key = f'{self.addr.stream_key}.{self.direction_keys[0]}'
         _s = asyncio.shield
 
         async def _xack(raw_msg):
@@ -68,10 +72,88 @@ class RedisStreamConnection(AbstractConnection):
 
     async def send_message(self, raw_msg: Tuple[bytes, bytes]) -> None:
         # assert not self.transport._redis.closed
-        stream_key = f'{self.addr.stream_key}.{self.direction_keys[1]}'
+        if not self.direction_keys:
+            stream_key = self.addr.stream_key
+        else:
+            stream_key = f'{self.addr.stream_key}.{self.direction_keys[1]}'
         _s = asyncio.shield
         await _s(self.transport._redis.xadd(
             stream_key, {b'hdr': raw_msg[0], b'msg': raw_msg[1]}))
+
+
+class CommonStreamBinder(AbstractBinder):
+    '''
+    CommonStreamBinder is for use with Publisher class.
+    All Publishers using CommonStreamBinder are supposed to provide the same stream key for the purposes
+    of subsequent message load-balancing among those, who read messages from the stream (Subscribers).
+    '''
+
+    __slots__ = ('transport', 'addr')
+
+    transport: RedisStreamTransport
+    addr: RedisStreamAddress
+
+    async def __aenter__(self):
+        self.transport._redis = await aioredis.create_redis(
+            self.addr.redis_server,
+            **self.transport._redis_opts)
+        key = self.addr.stream_key
+        #If there were no stream with the specified key before, it is created as a side effect of adding the message.
+        await self.transport._redis.xadd(key, {b'meta': b'create-or-join-to-stream'})
+        if self.addr.group:
+            raise ClientError("Group must not be specified in RedisStreamAddress, as objects\
+                using CommonStreamBinder are not supposed to be the consumers of any group.")
+        if self.addr.consumer:
+            raise ClientError("Consumer must not be specified in RedisStreamAddress, as objects\
+                using CommonStreamBinder are not supposed to be the consumers of any group.")
+        return RedisStreamConnection(self.transport, self.addr)
+
+    async def __aexit__(self, exc_type, exc_obj, exc_tb):
+        pass
+
+
+class CommonStreamConnector(AbstractConnector):
+    '''
+    CommonStreamConnector is for ise with Subscriber class.
+    All Subscribers using CommonStreamConnector are supposed to provide the same stream key and same group name
+    for the purposes of subsequent load-balancing. Based on the consumer group name, RedisStream will make sure
+    that each subscriber from the group gets distinct set of messages.
+    '''
+
+    __slots__ = ('transport', 'addr')
+
+    transport: RedisStreamTransport
+    addr: RedisStreamAddress
+
+    async def __aenter__(self):
+        pool = await aioredis.create_connection(
+            self.addr.redis_server,
+            **self.transport._redis_opts)
+        self.transport._redis = aioredis.Redis(pool)
+        key = self.addr.stream_key
+        #If there were no stream with the specified key before, it is created as a side effect of adding the message.
+        await self.transport._redis.xadd(key, {b'meta': b'create-or-join-to-stream'})
+        groups = await self.transport._redis.xinfo_groups(key)
+        if not any(map(lambda g: g[b'name'] == self.addr.group.encode(), groups)):
+            await self.transport._redis.xgroup_create(
+                key, self.addr.group)
+        return RedisStreamConnection(self.transport, self.addr)
+
+    async def __aexit__(self, exc_type, exc_obj, exc_tb):
+        # we need to create a new Redis connection for cleanup
+        # because self.transport._redis gets corrupted upon
+        # cancellation of Peer._recv_loop() task.
+        _redis = await aioredis.create_redis(
+            self.addr.redis_server,
+            **self.transport._redis_opts)
+        try:
+            await asyncio.shield(_redis.xgroup_delconsumer(
+                self.addr.stream_key,
+                self.addr.group,
+                self.addr.consumer))
+        finally:
+            _redis.close()
+            await _redis.wait_closed()
 
 
 class RedisStreamBinder(AbstractBinder):


### PR DESCRIPTION
I slightly messed up with the branching. Originally I wanted to merge only last 2 commits (instead of all 5 commits), but turned out that I branched out last 2 commits from already auxiliary branch rather than from master.

---

**Second part - New Message class**. Modified in last 2 commits.
Modified files: _"callosum/__init__.py"", "callosum/eventmessage.py", "callosum/message.py"_ .
- Created AbstractMessage abc.
- Created EventMessage class.
- Created MessageTypes enum class.

I made the following **assumptions**:
- There is no need to compress and use "snappy" for message compressing (Please, tell me if you want me to add it).
- There is no need to store and keep track of metadata for messages. So I didn't add it.
- Assumed that we need to encode **timestamp** (datetime object) into string and decode it from string during message transport.
- Always serialize args list using the serializer (and deserializer). Usually json serializer and deserializer.

---

**First part - _CommonStreamBinder_ and _CommonStreamConnector_ classes**. Modified in first 3 commits.
Modified files: _"callosum/exceptions.py"", "callosum/lower/redis.py"_ .
- As we discussed, I added new Binder and new Connector specific for Publisher and Subscriber classes. 

I made the following **assumptions**:
- I need to define new ParamError. This error will make the users not to input any "group" or "consumer" arguments for _RedisStreamAddress_ from the **Binder** side, since Binder (Publisher) only adds messages and doesn't need to subscribe and create any consumer group.
- I need to parametrize _RedisStreamConnection_ instead of creating new Connection class from scratch. Now, if the user does not provide any _"direction_keys"_, then it means that it is *unidirectional* connection, thus we only _recv_message (Subscriber) and _send_message (Publisher) only to the single same stream.