### PR TITLE
fix: Use only declared zmq constants for monitor events

### DIFF
--- a/changes/20.fix.md
+++ b/changes/20.fix.md
@@ -1,0 +1,1 @@
+Fix pyzmq attribute error on Ubuntu 20.04 at aarch64, which is built using older libzeromq without some socket monitoring event constants, by loading the constant declarations dynamically

--- a/src/callosum/lower/zeromq.py
+++ b/src/callosum/lower/zeromq.py
@@ -180,22 +180,9 @@ class ZeroMQMonitorMixin:
     _monitor_sock: Optional[zmq.Socket]
 
     EVENT_MAP = {
-        zmq.EVENT_MONITOR_STOPPED: "monitor-stopped",
-        zmq.EVENT_ACCEPT_FAILED: "accept-failed",
-        zmq.EVENT_ACCEPTED: "accepted",
-        zmq.EVENT_BIND_FAILED: "bind-failed",
-        zmq.EVENT_LISTENING: "listening",
-        zmq.EVENT_CLOSE_FAILED: "close-failed",
-        zmq.EVENT_CLOSED: "closed",
-        zmq.EVENT_CONNECTED: "connected",
-        zmq.EVENT_CONNECT_DELAYED: "connect-delayed",
-        zmq.EVENT_CONNECT_RETRIED: "connect-retried",
-        zmq.EVENT_DISCONNECTED: "disconnected",
-        zmq.EVENT_HANDSHAKE_FAILED_AUTH: "handshake-faield-auth",
-        zmq.EVENT_HANDSHAKE_FAILED_NO_DETAIL: "handshake-failed-no-detail",
-        zmq.EVENT_HANDSHAKE_FAILED_PROTOCOL: "handshake-failed-protocol",
-        zmq.EVENT_HANDSHAKE_SUCCEEDED: "handshake-succeeded",
-        zmq.EVENT_ALL: "all",
+        getattr(zmq.constants, name): name[6:].replace("_", "-").lower()
+        for name in dir(zmq.constants)
+        if name.startswith("EVENT_")
     }
 
     async def _monitor(self) -> None:

--- a/src/callosum/lower/zeromq.py
+++ b/src/callosum/lower/zeromq.py
@@ -179,6 +179,8 @@ class ZeroMQMonitorMixin:
 
     _monitor_sock: Optional[zmq.Socket]
 
+    # FIXME: Upon release pyzmq 23.0 or 22.4, take the constant declarations
+    #        from the zmq.constants.Event enum class, instead of doing dir().
     EVENT_MAP = {
         getattr(zmq.constants, name): name[6:].replace("_", "-").lower()
         for name in dir(zmq.constants)


### PR DESCRIPTION
resolves lablup/backend.ai#376.

Checking "EVENT_" prefix is not a very accurate implementation,
as the main (unreleased) branch of pyzmq shows:
https://github.com/zeromq/pyzmq/blob/8d406b6e1/zmq/constants.py#L271

Though, previously we anyway hard-coded only "EVENT_"-prefixed constants
and there is no difference in terms of the accuracy.

I personally want to avoid using `dir()` to iterate over arbitrary
module contents to *import* constant declarations, but this is
inevitable because pyzmq seems to heavily refactor the constant
modules to better support static typing in the upcoming release.

- `zmq.constants` will become a separate module based on Python enums
  insteed of being imported from Cython-based runtime-loaded
  `zmq.sugar.constants`.
- Currently mypy does not recognize `zmq.sugar.constants.base_names`
  because it's an imported name.
- `zmq.utils.constant_names.base_names` will be removed (!) and this
  means that it's a private API of the pyzmq library.
- It is the best to use the next release's `zmq.constants.Event` enum
  declaration, but it is not released yet.