### PR TITLE
refactor: Refine auth logging

### DIFF
--- a/changes/24.fix.md
+++ b/changes/24.fix.md
@@ -1,0 +1,1 @@
+Prevent leaking secret keys in the logs and allow infinite timeouts on connection pings

--- a/src/callosum/lower/zeromq.py
+++ b/src/callosum/lower/zeromq.py
@@ -414,7 +414,7 @@ class ZeroMQBaseConnector(ZeroMQMonitorMixin, AbstractConnector):
         self._main_sock = client_sock
         self.transport._sock = client_sock
         try:
-            await self.ping()
+            await self.ping(ping_timeout=5000)
         except asyncio.TimeoutError:
             raise AuthenticationError
         handshake_done = time.perf_counter()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -125,6 +125,7 @@ async def client(
         serializer=lambda o: json.dumps(o).encode("utf8"),
         deserializer=lambda b: json.loads(b),
         invoke_timeout=2.0,
+        transport_opts={"handshake_timeout": 0.2},
     )
     async with peer:
         resp = await peer.invoke("echo", {"sent": "asdf"})


### PR DESCRIPTION
- We should leave only public keys in the logs.
- Allow custom/infinite timeout for the first ping (handshake).
