### PR TITLE
chore: Relax yarl version requirements

### DIFF
--- a/changes/28.fix.md
+++ b/changes/28.fix.md
@@ -1,0 +1,1 @@
+Relax yarl version requirements to avoid potential dependency conflicts in the downstream Backend.AI platform

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     python-dateutil>=2.8.2
     msgpack>=1.0.7
     temporenc>=0.1
-    yarl>=1.9.4
+    yarl>=1.8.2,!=1.9.0,!=1.9.1,!=1.9.2
 zip_safe = false
 include_package_data = true
 


### PR DESCRIPTION
- Exclude some versions to avoid a former bug related with trailing
  slash handling (aio-libs/yarl#862).
