### PR TITLE
feat: Support to serialize ExceptionGroup

### DIFF
--- a/src/callosum/rpc/channel.py
+++ b/src/callosum/rpc/channel.py
@@ -370,9 +370,9 @@ class Peer(AbstractChannel):
                 server_cancelled = True
                 raise asyncio.CancelledError
             elif response.msgtype == RPCMessageTypes.FAILURE:
-                raise RPCUserError(*attrs.astuple(response.metadata))
+                raise RPCUserError.from_err_metadata(response.metadata)
             elif response.msgtype == RPCMessageTypes.ERROR:
-                raise RPCInternalError(*attrs.astuple(response.metadata))
+                raise RPCInternalError.from_err_metadata(response.metadata)
             return upper_result
         except (asyncio.TimeoutError, asyncio.CancelledError):
             # propagate cancellation to the connected peer

--- a/src/callosum/rpc/exceptions.py
+++ b/src/callosum/rpc/exceptions.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Self
+
 from ..exceptions import CallosumError
+
+if TYPE_CHECKING:
+    from .message import ErrorMetadata
 
 
 class RPCError(CallosumError):
@@ -6,7 +13,26 @@ class RPCError(CallosumError):
     A base exception for all RPC-specific errors.
     """
 
-    pass
+    name: str
+    repr: str
+    traceback: str
+    exceptions: tuple
+
+    def __init__(self, name: str, repr_: str, tb: str, exceptions: tuple, *args):
+        super().__init__(name, repr_, tb, *args)
+        self.name = name
+        self.repr = repr_
+        self.traceback = tb
+        self.exceptions = exceptions
+
+    @classmethod
+    def from_err_metadata(cls, metadata: ErrorMetadata) -> Self:
+        return cls(
+            metadata.name,
+            metadata.repr,
+            metadata.traceback,
+            tuple(cls.from_err_metadata(err) for err in metadata.sub_errors),
+        )
 
 
 class RPCUserError(RPCError):
@@ -14,28 +40,7 @@ class RPCUserError(RPCError):
     Represents an error caused in user-defined handlers.
     """
 
-    name: str
-    repr: str
-    traceback: str
-
-    def __init__(self, name: str, repr_: str, tb: str, *args):
-        super().__init__(name, repr_, tb, *args)
-        self.name = name
-        self.repr = repr_
-        self.traceback = tb
-
-
 class RPCInternalError(RPCError):
     """
     Represents an error caused in Calloum's internal logic.
     """
-
-    name: str
-    repr: str
-    traceback: str
-
-    def __init__(self, name: str, repr_: str, tb: str, *args):
-        super().__init__(name, tb, *args)
-        self.name = name
-        self.repr = repr_
-        self.traceback = tb


### PR DESCRIPTION
`callosum.rpc.message.ErrorMetadata` has `sub_errors` field to contain sub exceptions of ExceptionGroup. `callosum.rpc.channel.Peer` raises `RPCUserError` or `RPCInternalError` derived from the ErrorMetadata, which has `exceptions` field that has sub exceptions.
Peer side can access to sub exceptions by `RPCUserError.exceptions` or `RPCInternalError.exceptions`.