### PR TITLE
fix(rpc): pop the correct _req_idmap entry when a function task completes

### DIFF
--- a/changes/49.fix.md
+++ b/changes/49.fix.md
@@ -1,0 +1,1 @@
+Fix the RPC server-side `_req_idmap` growing unboundedly: the per-request done-callback captured the receive-loop variables by reference, popping the newest request's entry instead of its own whenever RPCs overlapped — which also silently disabled CANCEL handling for the newest request.

--- a/src/callosum/rpc/channel.py
+++ b/src/callosum/rpc/channel.py
@@ -180,10 +180,18 @@ class Peer(AbstractChannel):
                         )
                         func_tasks.add(task)
                         task.add_done_callback(func_tasks.discard)
+                        # Bind the key as a default argument: the callback runs
+                        # after the loop has rebound `request` and
+                        # `client_request_id` to a newer message, so a plain
+                        # closure would pop the newest entry instead of its own,
+                        # leaking this entry forever and breaking CANCEL for the
+                        # newest request.
                         task.add_done_callback(
-                            lambda task: self._req_idmap.pop(
-                                (request.peer_id, client_request_id),
-                                None,
+                            lambda task, key=(request.peer_id, client_request_id): (
+                                self._req_idmap.pop(
+                                    key,
+                                    None,
+                                )
                             )
                         )
                         await asyncio.sleep(0)

--- a/src/callosum/rpc/channel.py
+++ b/src/callosum/rpc/channel.py
@@ -180,18 +180,16 @@ class Peer(AbstractChannel):
                         )
                         func_tasks.add(task)
                         task.add_done_callback(func_tasks.discard)
-                        # Bind the key as a default argument: the callback runs
+                        # Bind the key eagerly via partial: the callback runs
                         # after the loop has rebound `request` and
                         # `client_request_id` to a newer message, so a plain
                         # closure would pop the newest entry instead of its own,
                         # leaking this entry forever and breaking CANCEL for the
                         # newest request.
                         task.add_done_callback(
-                            lambda task, key=(request.peer_id, client_request_id): (
-                                self._req_idmap.pop(
-                                    key,
-                                    None,
-                                )
+                            functools.partial(
+                                self._discard_req_idmap_entry,
+                                (request.peer_id, client_request_id),
                             )
                         )
                         await asyncio.sleep(0)
@@ -276,6 +274,13 @@ class Peer(AbstractChannel):
             await self._transport.close()
         # TODO: add proper cleanup for awaiting on
         # finishing of the "listen" coroutine's spawned tasks
+
+    def _discard_req_idmap_entry(
+        self,
+        key: Tuple[Any, RequestId],
+        _task: "asyncio.Task[None]",
+    ) -> None:
+        self._req_idmap.pop(key, None)
 
     def _next_client_seq_id(self) -> int:
         current = self._client_seq_id

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -389,3 +389,66 @@ async def test_internal_context_destroyed_on_close() -> None:
     # Verify context IS destroyed after transport close
     assert server_zctx.closed
     assert client_zctx.closed
+
+
+@pytest.mark.asyncio
+async def test_req_idmap_emptied_after_overlapping_calls() -> None:
+    """
+    Regression test for the done-callback closure bug: the callback captured
+    the receive-loop variables by reference, so a function task that finished
+    after a newer request had arrived popped the newer request's entry from
+    ``_req_idmap`` instead of its own, stranding its own entry forever (and
+    silently disabling CANCEL for the newer request).
+    """
+    done = asyncio.Event()
+    first_may_return = asyncio.Event()
+
+    async def func(request: RPCMessage) -> int:
+        body = cast(Mapping[str, int], request.body)
+        if body["idx"] == 0:
+            # Keep the first call in flight until the second call completes,
+            # so the first task's done-callback runs only after the receive
+            # loop has moved on to the newer request.
+            await first_may_return.wait()
+        else:
+            first_may_return.set()
+        return body["idx"]
+
+    server = Peer(
+        bind=ZeroMQAddress("tcp://127.0.0.1:5021"),
+        transport=ZeroMQRPCTransport,
+        scheduler=ExitOrderedAsyncScheduler(),
+        serializer=lambda o: json.dumps(o).encode("utf8"),
+        deserializer=lambda b: json.loads(b),
+    )
+    server.handle_function("func", func)
+
+    async def serve() -> None:
+        async with server:
+            await done.wait()
+
+    async def request() -> None:
+        client = Peer(
+            connect=ZeroMQAddress("tcp://localhost:5021"),
+            transport=ZeroMQRPCTransport,
+            serializer=lambda o: json.dumps(o).encode("utf8"),
+            deserializer=lambda b: json.loads(b),
+        )
+        async with client:
+            first = asyncio.create_task(
+                client.invoke("func", {"idx": 0}, order_key="k0")
+            )
+            # Make sure the first request is received and its task is waiting
+            # before the second request rebinds the receive-loop variables.
+            await asyncio.sleep(0.2)
+            second = asyncio.create_task(
+                client.invoke("func", {"idx": 1}, order_key="k1")
+            )
+            results = await asyncio.gather(first, second)
+            assert sorted(cast(List[int], results)) == [0, 1]
+        done.set()
+
+    server_task = asyncio.create_task(serve())
+    client_task = asyncio.create_task(request())
+    await asyncio.gather(server_task, client_task)
+    assert server._req_idmap == {}


### PR DESCRIPTION
## The bug

The per-request done-callback in the server-side receive loop closed over the loop variables by reference:

```python
async for raw_msg in agen:
    request = RPCMessage.decode(raw_msg, self._deserializer)
    client_request_id = request.request_id
    ...
    task.add_done_callback(
        lambda task: self._req_idmap.pop(
            (request.peer_id, client_request_id),  # rebound by the loop!
            None,
        )
    )
```

Whenever a function task finishes **after** the loop has already received a newer message (i.e. any overlapping RPCs), the callback pops the *newest* request's entry instead of its own. Two consequences:

1. **Unbounded leak**: the finished task's own entry is never removed from `_req_idmap` — roughly one stranded entry per overlapping RPC, forever, on any long-lived server peer. We found this on a production agent process via `tracemalloc`: the retained-object diff showed `channel.py` / `message.py` / `serialize.py` / zmq peer-id allocations all growing in lockstep (~1 set per incoming RPC over 21 hours), which turned out to be exactly the components of stranded `_req_idmap` entries.
2. **Broken CANCEL**: the newest request's entry is popped prematurely, so a subsequent `CANCEL` for it finds nothing and is silently ignored.

## The fix

Bind the key eagerly with `functools.partial` and a small named helper (a lambda default argument also works, but mypy cannot infer its type), so each callback pops its own entry:

```python
task.add_done_callback(
    functools.partial(
        self._discard_req_idmap_entry,
        (request.peer_id, client_request_id),
    )
)
```

## Test

`test_req_idmap_emptied_after_overlapping_calls` overlaps two calls (the first stays in flight until the second completes) and asserts `server._req_idmap == {}` afterwards.

- On the previous code: **fails** (one stranded entry)
- With the fix: passes; full `tests/test_rpc.py` suite passes (11/11); pre-commit (ruff, ruff-format, mypy) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)